### PR TITLE
start to update the examples for Purescript 0.9.3, closes #11

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,7 @@ gulp.task('compile', function(cb) {
 	var psc = purescript.psc({
 		// Compiler options
     src: [paths.purescripts, paths.bowerSrc],
-    ffi: paths.ffi,
+
 		output: "output",
     module: "Graphics.D3.Examples"
 	});

--- a/src/BarChart1.purs
+++ b/src/BarChart1.purs
@@ -1,6 +1,6 @@
 module Graphics.D3.Examples.BarChart1 where
 
-import Prelude(id,(++),show,return,unit,Unit(),(>>=),bind)
+import Prelude(id,(<>),show,unit,Unit(),(>>=),bind)
 import Graphics.D3.Base
 import Graphics.D3.Util
 import Graphics.D3.Selection
@@ -41,5 +41,5 @@ main = do
     .. selectAll "div"
       .. bindData array
     .. enter .. append "div"
-      .. style' "width" (\d -> show (x d) ++ "px")
+      .. style' "width" (\d -> show (x d) <> "px")
       .. text' show

--- a/src/BarChart2.purs
+++ b/src/BarChart2.purs
@@ -1,6 +1,6 @@
 module Graphics.D3.Examples.BarChart2 where
 
-import Prelude(map,(*),(++),show,(>>>),(-),(/),bind,($))
+import Prelude(map,(*),(<>),show,(>>>),(-),(/),bind,($))
 import Data.Either
 import Data.Array (length)
 import Data.Traversable
@@ -85,7 +85,7 @@ main = do
     bar <- chart ... selectAll "g"
         .. bindData typedData
       .. enter .. append "g"
-        .. attr'' "transform" (\_ i -> "translate(0," ++ show (i * barHeight) ++ ")")
+        .. attr'' "transform" (\_ i -> "translate(0," <> show (i * barHeight) <> ")")
 
     bar ... append "rect"
       .. attr' "width" (_.value >>> x)

--- a/src/BarChart3.purs
+++ b/src/BarChart3.purs
@@ -1,6 +1,6 @@
 module Graphics.D3.Examples.BarChart3 where
 
-import Prelude(map,(-),(+),(++),show,(<$>),(<<<),bind)
+import Prelude(map,(-),(+),(<>),show,(<$>),(<<<),bind)
 import Data.Either
 import Data.Array (length)
 import Data.Traversable
@@ -117,7 +117,7 @@ main = do
     .. attr "width" (width + margin.left + margin.right)
     .. attr "height" (height + margin.top + margin.bottom)
     .. append "g"
-      .. attr "transform" ("translate(" ++ show margin.left ++ "," ++ show margin.top ++ ")")
+      .. attr "transform" ("translate(" <> show margin.left <> "," <> show margin.top <> ")")
 
   tsv "data/lettersAndFrequencies.tsv" \(Right array) -> do
     typedData <- traverse coerceDatum array
@@ -131,7 +131,7 @@ main = do
 
     svg ... append "g"
       .. attr "class" "x axis"
-      .. attr "transform" ("translate(0," ++ show height ++ ")")
+      .. attr "transform" ("translate(0," <> show height <> ")")
       .. renderAxis xAxis
 
     svg ... append "g"

--- a/src/ForceLayout1.purs
+++ b/src/ForceLayout1.purs
@@ -11,7 +11,7 @@ import Graphics.D3.Request
 import Graphics.D3.Scale
 import Graphics.D3.Selection
 import Graphics.D3.Util
-import Prelude(Unit(),bind)
+import Prelude(Unit(),bind,negate)
 
 -- | This is a PureScript adaptation of the Sticky Force Layout example:
 -- | http://bl.ocks.org/mbostock/3750558


### PR DESCRIPTION
Hello, this is mostly to discuss the changes with you in order to be faster. I tried to build with Purescript 0.9.3 and i've got a failure, 4 errors and 19 warnings.

The failure was due to the `ffi` option passed to the compiler, it's not supported anymore. I removed it but i guess that this is not a solution. At the moment i couldn't find any documentation about how to specify the Javascript files to include. Maybe now the compiler is able to find the files automatically?

About the rest, i fixed the easy errors due to the changes in the prelude. I still have a more complex type checker error in the force layout example, which i need to look again with more calm. In the meantime i wanted to reach out in order to get some feedback about the general direction, since i see that the repo hasn't had commits in a while.

Cheers,
Francesco
